### PR TITLE
Randomized pipes

### DIFF
--- a/CVProcessor/Utilities.h
+++ b/CVProcessor/Utilities.h
@@ -158,6 +158,28 @@ static uint64 GetTimeMs64()
 #endif
 }
 
+//===========================================================================
+// Generate a random alphanumeric string of a given length
+// Mostly courtesy of Ates Goral https://stackoverflow.com/a/440240
+//===========================================================================
+
+static std::string generateRandomString(const int len) {
+    static const char alphanum[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+        
+    std::string returnStr = "";
+
+    srand(time(NULL));
+
+    for (int i = 0; i < len; ++i) {
+        returnStr += alphanum[rand() % (sizeof(alphanum) - 1)];
+    }
+
+    return returnStr;
+}
+
 }
 
 #endif /* UTILITIES_H */

--- a/CVProcessor/VideoProcessing.cpp
+++ b/CVProcessor/VideoProcessing.cpp
@@ -24,6 +24,7 @@
 #include <tuple>
 #include <signal.h>
 #include <future>
+#include <regex>
 
 
 #include <sys/types.h>
@@ -249,7 +250,7 @@ void processVideoStream(const std::string& inPipe,
     
     tStart = Utilities::GetTimeMs64();
     
-    const std::string outPipeName = "cvprocessor-out";
+    const std::string outPipeName = "pipe-o-" + Utilities::generateRandomString(10);
     createFIFO(outPipeName);
     
     // Start up read end of pipe
@@ -330,7 +331,7 @@ void VideoProcessing::processVideoStream(const std::string& inputStream)
         metadata.frameRateDenom = 1;
     }
     
-    const std::string inPipeName = "cvprocessor-in";
+    const std::string inPipeName = "pipe-i-" + Utilities::generateRandomString(10);
     createFIFO(inPipeName);
     
     int extractionProcessID = FFMPEGProcessing::extractFramesFromStream(Config::videoStream, 
@@ -338,3 +339,4 @@ void VideoProcessing::processVideoStream(const std::string& inputStream)
 
     processVideoStream(inPipeName, metadata);
 }
+


### PR DESCRIPTION
Fix for #17, for streaming only. Right now I'm generating a different name for the in & out pipe, as opposed to making them the same but adding -in or -out. (I still add a pipe-i- or pipe-o- at the beginning but the rest is different.) Not sure if that matters.

Another problem is the pipes stick around basically forever since they never get overwritten. Again, not sure if this matters.